### PR TITLE
fix: pin rollup binary to 4.62.2 and restore lockfile to fix GoCD GLIBC failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
         "@types/node": "^25.9.5"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.62.2",
-        "@rollup/rollup-linux-x64-musl": "^4.62.2"
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -633,6 +633,44 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/@devframes/hub": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@devframes/hub/-/hub-0.7.15.tgz",
+      "integrity": "sha512-g2aUJZAsmBsWARqvA2nhT5F9v2usJ/uiavstsWA7FZaXU6+2LYx/OafqDlFNUa+PxGUWwEZe/qzwAuRoZjv8uA==",
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "^4.0.0",
+        "destr": "^2.0.5",
+        "nostics": "^1.2.0",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "tinyexec": "^1.2.4",
+        "zigpty": "^0.2.1"
+      },
+      "peerDependencies": {
+        "devframe": "0.7.15"
+      }
+    },
+    "node_modules/@devframes/json-render": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@devframes/json-render/-/json-render-0.7.15.tgz",
+      "integrity": "sha512-IB1EsAHKK313yuslrEyAl7z6347YeV+eT5EtNQwjLcoYh1sD6er/eqdj4Aeicovpg49U7tmlFZHicDxVl1W89A==",
+      "license": "MIT",
+      "dependencies": {
+        "@json-render/core": "^0.19.0",
+        "nostics": "^1.2.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@devframes/hub": "0.7.15",
+        "devframe": "0.7.15"
+      },
+      "peerDependenciesMeta": {
+        "@devframes/hub": {
+          "optional": true
+        }
       }
     },
     "node_modules/@dxup/nuxt": {
@@ -3467,9 +3505,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -3480,9 +3518,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
-      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -3647,7 +3685,7 @@
       "version": "25.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
       "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -3791,123 +3829,6 @@
       },
       "peerDependencies": {
         "vite": "*"
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/@devframes/hub": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@devframes/hub/-/hub-0.7.15.tgz",
-      "integrity": "sha512-g2aUJZAsmBsWARqvA2nhT5F9v2usJ/uiavstsWA7FZaXU6+2LYx/OafqDlFNUa+PxGUWwEZe/qzwAuRoZjv8uA==",
-      "license": "MIT",
-      "dependencies": {
-        "birpc": "^4.0.0",
-        "destr": "^2.0.5",
-        "nostics": "^1.2.0",
-        "pathe": "^2.0.3",
-        "perfect-debounce": "^2.1.0",
-        "tinyexec": "^1.2.4",
-        "zigpty": "^0.2.1"
-      },
-      "peerDependencies": {
-        "devframe": "0.7.15"
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/@devframes/json-render": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@devframes/json-render/-/json-render-0.7.15.tgz",
-      "integrity": "sha512-IB1EsAHKK313yuslrEyAl7z6347YeV+eT5EtNQwjLcoYh1sD6er/eqdj4Aeicovpg49U7tmlFZHicDxVl1W89A==",
-      "license": "MIT",
-      "dependencies": {
-        "@json-render/core": "^0.19.0",
-        "nostics": "^1.2.0",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@devframes/hub": "0.7.15",
-        "devframe": "0.7.15"
-      },
-      "peerDependenciesMeta": {
-        "@devframes/hub": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/crossws": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
-      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "srvx": ">=0.11.5"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/devframe": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.7.15.tgz",
-      "integrity": "sha512-pHcCgDILv9BfF0oqEcpPzsPG/2/TLrhcYIUiWTNmP+YiyTmaGkW0osR/48STotnJNi3O2upj5L/6tpLOl/Ravg==",
-      "license": "MIT",
-      "dependencies": {
-        "@valibot/to-json-schema": "^1.7.1",
-        "birpc": "^4.0.0",
-        "crossws": "^0.4.10",
-        "destr": "^2.0.5",
-        "h3": "^2.0.1-rc.26",
-        "mrmime": "^2.0.1",
-        "nostics": "^1.2.0",
-        "pathe": "^2.0.3",
-        "ufo": "^1.6.4",
-        "valibot": "^1.4.2"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
-        "cac": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        },
-        "cac": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/h3": {
-      "version": "2.0.1-rc.26",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.26.tgz",
-      "integrity": "sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==",
-      "license": "MIT",
-      "dependencies": {
-        "rou3": "^0.9.1",
-        "srvx": "^0.12.4"
-      },
-      "bin": {
-        "h3": "bin/h3.mjs"
-      },
-      "engines": {
-        "node": ">=20.11.1"
-      },
-      "peerDependencies": {
-        "crossws": "^0.4.9"
-      },
-      "peerDependenciesMeta": {
-        "crossws": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -4802,14 +4723,12 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/cache-content-type": {
@@ -5022,14 +4941,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=16"
       }
     },
     "node_modules/commondir": {
@@ -5610,6 +5527,74 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
       "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
       "license": "MIT"
+    },
+    "node_modules/devframe": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.7.15.tgz",
+      "integrity": "sha512-pHcCgDILv9BfF0oqEcpPzsPG/2/TLrhcYIUiWTNmP+YiyTmaGkW0osR/48STotnJNi3O2upj5L/6tpLOl/Ravg==",
+      "license": "MIT",
+      "dependencies": {
+        "@valibot/to-json-schema": "^1.7.1",
+        "birpc": "^4.0.0",
+        "crossws": "^0.4.10",
+        "destr": "^2.0.5",
+        "h3": "^2.0.1-rc.26",
+        "mrmime": "^2.0.1",
+        "nostics": "^1.2.0",
+        "pathe": "^2.0.3",
+        "ufo": "^1.6.4",
+        "valibot": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "cac": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "cac": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devframe/node_modules/crossws": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devframe/node_modules/h3": {
+      "version": "2.0.1-rc.26",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.26.tgz",
+      "integrity": "sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==",
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.9.1",
+        "srvx": "^0.12.4"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.9"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -10074,6 +10059,32 @@
         }
       }
     },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/rou3": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.1.tgz",
@@ -10754,15 +10765,6 @@
         "url": "https://opencollective.com/svgo"
       }
     },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -11272,7 +11274,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -11829,15 +11831,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/antfu"
-      }
-    },
-    "node_modules/vite-node/node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/vite-plugin-checker": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/node": "^25.9.5"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.62.2",
-    "@rollup/rollup-linux-x64-musl": "^4.62.2"
+    "@rollup/rollup-linux-x64-gnu": "4.62.2",
+    "@rollup/rollup-linux-x64-musl": "4.62.2"
   }
 }


### PR DESCRIPTION
## Problem

GoCD CI was failing during `nuxt prepare` with:
```
GLIBC_2.32' not found (required by @rollup/rollup-linux-x64-gnu/rollup.linux-x64-gnu.node)
```

Two compounding issues:

1. **`package-lock.json` was deleted** — without it, `npm install` on CI resolves `^4.62.2` to the latest matching version (`4.62.3`), which introduced a `GLIBC_2.32` requirement
2. **GoCD agents run GLIBC_2.31** — `@rollup/rollup-linux-x64-gnu@4.62.3` cannot load, `nuxt prepare` fails

## Fix

- Pin `@rollup/rollup-linux-x64-gnu` and `@rollup/rollup-linux-x64-musl` to **exact `4.62.2`** (requires `GLIBC_2.14` only — confirmed by binary inspection)
- Restore and commit `package-lock.json` with `4.62.2` locked — GoCD reads from it directly, no resolution step, no chance of picking up a newer breaking version

## Test plan

- [ ] GoCD pipeline passes — no GLIBC error during `nuxt prepare`
- [ ] Fresh clone + `npm install` completes without errors
- [ ] `npm run build` succeeds
- [ ] `npm run dev` starts without issues